### PR TITLE
Update to O365 API Function Import

### DIFF
--- a/Update/UpdateAPIFunctions.ps1
+++ b/Update/UpdateAPIFunctions.ps1
@@ -9,6 +9,8 @@
     $includeAlias = $false
     )
 
+    #requires -RunAsAdministrator
+
 $actionWordsPath = "$PSScriptRoot\actionWords.csv"
 $unallowedWords = Get-Content "$PSScriptRoot\unallowedWords.txt"
 

--- a/WiscO365.psm1
+++ b/WiscO365.psm1
@@ -462,7 +462,7 @@ Function Update-O365APIFunctions{
             }
 
             #Reload the module
-            Import-Module WiscO365 -Force -DisableNameChecking
+            Import-Module WiscO365 -Force -DisableNameChecking -ErrorAction SilentlyContinue
 
             Try{
                 #Generate HTML documentation


### PR DESCRIPTION
Added a clause to the Update/UpdateAPIFunctions.ps1 file that will instruct users that this function needs to be elevated when executing to work properly (at least the first time when trying to update/generate documentation). Also added a suppression of an invalid module error thrown when this function is invoked from the WiscO365.psm1 file.